### PR TITLE
fix single-run-agents: replace run with runAndGetResult

### DIFF
--- a/docs/single-run-agents.md
+++ b/docs/single-run-agents.md
@@ -132,7 +132,7 @@ val agent = AIAgent(
 )
 
 fun main() = runBlocking {
-    val result = agent.run("Hello! How can you help me?")
+    val result = agent.runAndGetResult("Hello! How can you help me?")
 }
 ```
 


### PR DESCRIPTION
Hello!

I changed the example code with `runAndGetResult` instead of `run`, because the example expects the result (so the wrong function was used)