### PR TITLE
Rename "Advanced implementation" to "Class-based tools" for clarity

### DIFF
--- a/docs/annotation-based-tools.md
+++ b/docs/annotation-based-tools.md
@@ -6,7 +6,7 @@ By using annotations, you can transform any function into a tool that LLMs can u
 This approach is useful when you need to expose existing functionality to LLMs without implementing tool descriptions manually.
 
 !!! note
-    Annotation-based tools are JVM-only and not available for other platforms. For multiplatform support, use the [advanced tool API](advanced-tool-implementation.md).
+    Annotation-based tools are JVM-only and not available for other platforms. For multiplatform support, use the [class-based tool API](class-based-tools.md).
 
 ## Key annotations
 

--- a/docs/built-in-tools.md
+++ b/docs/built-in-tools.md
@@ -47,4 +47,4 @@ val agent = AIAgent(
 <!--- KNIT example-built-in-tools-01.kt -->
 
 You can create a comprehensive set of capabilities for your agent by combining built-in tools and custom tools within the same registry.
-To learn more about custom tools, see [Annotation-based tools](annotation-based-tools.md) and [Advanced implementation](advanced-tool-implementation.md).
+To learn more about custom tools, see [Annotation-based tools](annotation-based-tools.md) and [Class-based tools](class-based-tools.md).

--- a/docs/class-based-tools.md
+++ b/docs/class-based-tools.md
@@ -1,6 +1,6 @@
-# Advanced implementation
+# Class-based tools
 
-This section explains the advanced API designed for scenarios that require enhanced flexibility and customized behavior.
+This section explains the API designed for scenarios that require enhanced flexibility and customized behavior.
 With this approach, you have full control over a tool, including its parameters, metadata, execution logic, and how it is registered and invoked.
 
 This level of control is ideal for creating sophisticated tools that extend basic use cases, enabling seamless integration into agent sessions and workflows.
@@ -8,7 +8,7 @@ This level of control is ideal for creating sophisticated tools that extend basi
 This page describes how to implement a tool, manage tools through registries, call them, and use within node-based agent architectures.
 
 !!! note
-    The advanced tool API is multiplatform. This lets you use the same tools across different platforms.
+    The API is multiplatform. This lets you use the same tools across different platforms.
 
 ## Tool implementation
 

--- a/docs/tools-overview.md
+++ b/docs/tools-overview.md
@@ -17,8 +17,8 @@ There are three types of tools in the Koog framework:
 
 - Built-in tools that provide functionality for agent-user interaction and conversation management. For details, see [Built-in tools](built-in-tools.md).
 - Annotation-based custom tools that let you expose functions as tools to LLMs. For details, see [Annotation-based tools](annotation-based-tools.md).
-- Custom tools that are created using the advanced API and let you control tool parameters, metadata, execution logic, and how it is registered and invoked. For details, see [Advanced
-  implementation](advanced-tool-implementation.md).
+- Custom tools that let you control tool parameters, metadata, execution logic, and how it is registered and invoked. For details, see [Class-based
+  tools](class-based-tools.md).
 
 ### Tool registry
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,7 @@ nav:
           - Overview: tools-overview.md
           - Built-in tools: built-in-tools.md
           - Annotation-based tools: annotation-based-tools.md
-          - Advanced implementation: advanced-tool-implementation.md
+          - Class-based tools: class-based-tools.md
       - Agent events: agent-events.md
       - Agent strategies:
         - Custom strategy graphs: custom-strategy-graphs.md
@@ -54,6 +54,7 @@ plugins:
   - redirects:
       redirect_maps:
         'simple-api-getting-started.md': 'index.md'
+        'advanced-tool-implementation.md': 'class-based-tools.md'
 
 theme:
   name: material


### PR DESCRIPTION
The term _advanced implementation_ can be confusing to users, especially when this API is the only option.
 To improve clarity and avoid misunderstandings, I renamed it to _class-based tools_ as @Rizzen suggested. This also better aligns with the term _annotation-based tools_.